### PR TITLE
Fork binary instead of invoking shell

### DIFF
--- a/lib/Selenium/CanStartBinary.pm
+++ b/lib/Selenium/CanStartBinary.pm
@@ -375,7 +375,10 @@ sub shutdown_binary {
     }
 
     if($self->has_signal_shutdown_binary && $self->signal_shutdown_binary) {
-        kill(15, $self->binary_pid);
+        for my $sig (15, 2, 9) {
+            kill($sig, $self->binary_pid) or last;
+            sleep 1;
+        }
     }
 }
 

--- a/lib/Selenium/CanStartBinary.pm
+++ b/lib/Selenium/CanStartBinary.pm
@@ -310,6 +310,10 @@ sub _build_binary_mode {
     my $pid = fork();
     die 'Forking to launch binary failed' if not defined $pid;
     if (not $pid) {
+        # TODO: allow users to specify whether & where they want driver
+        # output to go
+        open(STDOUT, '>', IS_WIN ? '/nul' : '/dev/null') or die $!;
+        open(STDERR, '>&', \*STDOUT) or die $!;
         exec(@command) or die $!;
     }
     $self->binary_pid($pid);
@@ -425,9 +429,6 @@ sub _construct_command {
         push(@cmd, $self->custom_args);
     }
 
-    # Handle Windows vs Unix discrepancies for invoking shell commands
-    push(@cmd, $self->_cmd_suffix);
-
     return @cmd;
 }
 
@@ -450,18 +451,6 @@ sub _cmd_prefix {
             push(@prefix, '/MIN');
             return @prefix;
         }
-    }
-    else {
-        return ();
-    }
-}
-
-sub _cmd_suffix {
-    # TODO: allow users to specify whether & where they want driver
-    # output to go
-
-    if (IS_WIN) {
-        return ('>', '/nul', '2>&1');
     }
     else {
         return ();

--- a/lib/Selenium/Chrome.pm
+++ b/lib/Selenium/Chrome.pm
@@ -72,13 +72,13 @@ has 'binary_port' => (
 
 has '_binary_args' => (
     is => 'lazy',
-    builder => sub {
+    default => sub {
         my ($self) = @_;
 
         my $context = $self->wd_context_prefix;
         $context =~ s{^/}{};
 
-        return ' --port=' . $self->port . ' --url-base=' . $context . ' ';
+        return ['--port', $self->port, '--url-base', $context];
     }
 );
 

--- a/lib/Selenium/Firefox.pm
+++ b/lib/Selenium/Firefox.pm
@@ -145,18 +145,16 @@ result some options may be overwritten or ignored.
 
 has '_binary_args' => (
     is => 'lazy',
-    builder => sub {
+    default => sub {
         my ($self) = @_;
 
         if ( $self->marionette_enabled ) {
-            my $args = ' --port ' . $self->port
-              . ' --marionette-port ' . $self->marionette_binary_port
-              . ' --binary "' . $self->firefox_binary . '"';
-
-            return $args;
+            return ['--port', $self->port,
+                    '--marionette-port', $self->marionette_binary_port,
+                    '--binary', $self->firefox_binary];
         }
         else {
-            return ' -no-remote';
+            return ['-no-remote'];
         }
     }
 );
@@ -244,6 +242,11 @@ has 'firefox_binary' => (
     builder => 'firefox_path'
 );
 
+has 'signal_shutdown_binary' => (
+    is => 'ro',
+    default => sub { 1 },
+    predicate => 1
+);
 
 with 'Selenium::CanStartBinary';
 

--- a/lib/Selenium/PhantomJS.pm
+++ b/lib/Selenium/PhantomJS.pm
@@ -85,10 +85,10 @@ has 'binary_port' => (
 
 has '_binary_args' => (
     is => 'lazy',
-    builder => sub {
+    default => sub {
         my ($self) = @_;
 
-        return ' --webdriver=127.0.0.1:' . $self->port;
+        return ['--webdriver', '127.0.0.1:' . $self->port];
     }
 );
 


### PR DESCRIPTION
This patch forks the browser binary, instead of calling `system` & setting it to the background. The incentive is https://github.com/gempesaw/Selenium-Remote-Driver/issues/280 As I haven't worked with portability before, I am unsure about `fork`, `open` (redirection), `kill` portability consequences.

Notes:
- used `exec LIST` with multiple elements in LIST, because if [there is only 1 element](http://perldoc.perl.org/functions/exec.html) (ie the string of the command to execute, arguments included in the string) 

>  If there is only one element in LIST, the argument is checked for shell metacharacters, and if there are any, the entire argument is passed to the system's command shell for parsing (this is /bin/sh -c on Unix platforms, but varies on other platforms). 

Unfortunately, this meant that I did changes in lots of places :(
- The binary now executes in the foreground (in the child process) and not in the background (see above)
- Double quotes, both for the program and the `--binary` argument, confused exec so I had to remove them. There is an SRD comment about paths that could contain spaces (totally makes sense), that is completely **ignored** in this patch.
- For windows, I didn't know where to apply the `2>&1` part for STDERR to STDOUT redirection (I am unsure if open's redirection is portable and has the same effect)
- I added the attribute `Selenium::Firefox::signal_shutdown_binary` to demo the change, there might be a better way to do it (and avoid the extra attribute)?
- I had to do a Moo workaround (I am a Moo-noob :) ) to assign arrayref to an attribute, and I converted `builder` to `default`. There might be a more elegant solution to this, and I am not sure if this has any side effects.

I tested this with geckodriver 0.10 and firefox 49 and it works ok. geckodriver is launched, no STDERR/STDOUT from the child is printed (so the redirection seems to be working), and after some webdriver commands `shutdown_binary` does signal the child. When the main program exits, there is neither firefox or geckodriver running.

Happy to do more coding and/or tests if needed. Happy to code alternatives if the change looks too pervasive (but I'll might some directions).
