### PR TITLE
Fix set_timeout and move_to for Selenium::Firefox

### DIFF
--- a/lib/Selenium/Remote/Commands.pm
+++ b/lib/Selenium/Remote/Commands.pm
@@ -344,6 +344,11 @@ has '_cmds' => (
                 'url'                => 'session/:sessionId/buttonup',
                 'no_content_success' => 1
             },
+            'generalAction' => {
+                'method'             => 'POST',
+                'url'                => 'session/:sessionId/actions',
+                'no_content_success' => 1
+            },
             'uploadFile' => {
                 'method'             => 'POST',
                 'url'                => 'session/:sessionId/file',

--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -1096,7 +1096,7 @@ sub set_timeout {
     $ms = _coerce_timeout_ms( $ms );
 
     my $res = { 'command' => 'setTimeout' };
-    my $params = { 'type' => $type, 'ms' => $ms };
+    my $params = { 'type' => $type, 'ms' => $ms, $type => $ms };
     return $self->_execute_command( $res, $params );
 }
 

--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -1008,6 +1008,46 @@ sub move_to {
     return shift->mouse_move_to_location(@_);
 }
 
+=head2 move_action
+
+ Description:
+    Move the mouse similarly to the mouse_move_to_location. But uses the
+    new webdriver actions API which is supported by geckodriver.
+
+ Output:
+    STRING -
+
+ Usage:
+    # element - the element to move to. Must be specified.
+    # xoffset - X offset to move to, relative to the center of the element. If not specified, the mouse will move to the middle of the element.
+    # yoffset - Y offset to move to, relative to the center of the element. If not specified, the mouse will move to the middle of the element.
+
+    print $driver->move_action(element => e, xoffset => x, yoffset => y);
+
+=cut
+
+sub move_action {
+    my ( $self, %args ) = @_;
+    my $params = {
+        actions => [{
+            type => "pointer",
+            id => 'my pointer move',
+            "parameters" => { "pointerType" => "mouse" },
+            actions => [
+                {
+                    type => "pointerMove",
+                    duration => 0,
+                    x => $args{xoffset} // 0,
+                    y => $args{yoffset} // 0,
+                    origin => {'element-6066-11e4-a52e-4f735466cecf' => $args{element}{id}},
+                },
+            ],
+        }],
+    };
+    my $res = { 'command' => 'generalAction' };
+    return $self->_execute_command( $res, $params );
+}
+
 =head2 get_capabilities
 
  Description:


### PR DESCRIPTION
Geckodriver seems to follow very strictly the new W3C API.

* set timeout: [Relevant part of the Specs][1]
* move_to: uses the new actions API, [Relevant part of the Specs][2]


[1]: https://w3c.github.io/webdriver/webdriver-spec.html#set-timeouts
[2]: https://w3c.github.io/webdriver/webdriver-spec.html#pointer-actions