### PR TITLE
Fix #329 -- Uninitialized value warnings in S::R::Commands

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -42,6 +42,7 @@ on 'test' => sub {
   requires "Test::Fatal" => "0";
   requires "Test::LWP::UserAgent" => "0";
   requires "Test::More" => "0";
+  requires "Test::NoWarnings" => "0";
   requires "Test::Time" => "0";
   requires "Test::Warn" => "0";
   requires "lib" => "0";

--- a/lib/Selenium/Remote/Commands.pm
+++ b/lib/Selenium/Remote/Commands.pm
@@ -455,6 +455,8 @@ sub get_params {
     my $command = $args->{'command'};
     my $url     = $self->get_url($command);
 
+    # Issue 329 -- Suppress unint value warns
+    $args = { map { $_ => $args->{$_} ? $args->{$_} : "" } qw{session_id id name property_name other window_handle} };
     # Do the var substitutions.
     $url =~ s/:sessionId/$args->{'session_id'}/;
     $url =~ s/:id/$args->{'id'}/;

--- a/t/04-commands-implemented.t
+++ b/t/04-commands-implemented.t
@@ -1,36 +1,56 @@
 use strict;
 use warnings;
 
-# TODO: find another way to do this checking, this is so fragile
-use Selenium::Remote::Commands;
-use Test::More;
+use Test::More tests => 3 + 1;
+use Test::NoWarnings;
 
-unless($ENV{RELEASE_TESTING}) {
-  plan(skip_all=>"Author tests not required for installation.");
+# Assume we're not using dzil test unless we're doing that
+if( !grep { index( $_, ".build" ) != -1 } @INC ) {
+  require Cwd;
+  require File::Basename;
+  push( @INC, File::Basename::dirname(Cwd::abs_path(__FILE__)) . "/../lib" );
 }
 
-my $comm = Selenium::Remote::Commands->new->get_cmds;
-for my $command (keys %{$comm}) {
-  my $found_command = 0;
-  for my $file (
-    qw{lib/Selenium/Remote/Driver.pm
-    lib/Selenium/Remote/WebElement.pm
-    lib/Selenium/Firefox.pm}
-    ) {
-    open(my $fh, '<', $file) or die "Couldn't open file $file";
-    for (<$fh>) {
-      if (/'?command'?\s*=>\s*'$command'/
-       or /{'?commands'?}->\{'?$command'?}/) {
-        pass("find $command");
-        $found_command = 1;
+require_ok( "Selenium::Remote::Commands" ) || die;
+
+subtest "All implemented commands are found" => sub {
+  plan skip_all => "Author tests not required for installation." unless $ENV{'RELEASE_TESTING'};
+  my $comm = Selenium::Remote::Commands->new->get_cmds;
+  for my $command (keys %{$comm}) {
+    my $found_command = 0;
+    for my $file (
+      qw{lib/Selenium/Remote/Driver.pm
+      lib/Selenium/Remote/WebElement.pm
+      lib/Selenium/Firefox.pm}
+      ) {
+      open(my $fh, '<', $file) or die "Couldn't open file $file";
+      for (<$fh>) {
+        if ( /'?command'?\s*=>\s*'$command'/ or /{'?commands'?}->\{'?$command'?}/) {
+          pass("find $command");
+          $found_command = 1;
+        }
       }
     }
+    if (!$found_command && $command !~ /Gecko/) {
+      fail("find $command");
+    }
   }
-  if (!$found_command && $command !~ /Gecko/) {
-    fail("find $command");
-  }
-}
+};
 
-done_testing;
+subtest "get_params() works as intended" => sub {
+  no warnings qw{redefine once};
+  # I know this is somewhat whimsical as an URL, but hey, it is a test.
+  local *Selenium::Remote::Commands::get_url = sub { return "http://foo.bar.baz:4444/session/:sessionId:id:name:propertyName:other:windowHandle" };
+  local *Selenium::Remote::Commands::get_method = sub { return 'methodMan'; };
+  local *Selenium::Remote::Commands::get_no_content_success = sub { return 'zippy' };
+  my $model_return = {
+    'method' => 'methodMan',
+    'no_content_success' => 'zippy',
+    'url' => 'http://foo.bar.baz:4444/session/12345'
+  };
+  my $bogus_obj = bless( {}, "Selenium::Remote::Commands" );
+  is( Selenium::Remote::Commands::get_params( $bogus_obj ), undef, "We return early when session_id not passed in" );
+  is_deeply( Selenium::Remote::Commands::get_params( $bogus_obj, { 'session_id' => "12345" } ), $model_return, "Expected data returned when minimal information input" );
+};
 
 1;


### PR DESCRIPTION
It just wasn't setting sane defaults before running regex replace.
This commit additionally adds test coverage for the modified
subroutine, hopefully in the correct place.

I also added a block to properly include the libdir when running
the affected test via prove (so that you don't have to use -Ilib
or something like that) whenever we're not running the test via
'dzil test' or anything else where we've plopped the libs and
tests in a temporary '.build' directory.