### PR TITLE
Make sure getElementAttribute is called for firefox to fix #376

### DIFF
--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -875,13 +875,14 @@ sub new_session {
     my $args = {
         'desiredCapabilities' => {
             'browserName'        => $self->browser_name,
-            'platform'           => $self->platform,
             'javascriptEnabled'  => $self->javascript,
             'version'            => $self->version,
             'acceptSslCerts'     => $self->accept_ssl_certs,
             %$extra_capabilities,
         },
     };
+    $args->{'extra_capabilities'}{'platform'} = $self->platform
+        if $self->browser_name ne 'firefox' || !$self->{is_wd3};
     $args->{'extra_capabilities'} = \%$extra_capabilities unless $FORCE_WD2;
 
 

--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -882,7 +882,7 @@ sub new_session {
         },
     };
     $args->{'desiredCapabilities'}{'platform'} = $self->platform
-        if $self->browser_name ne 'firefox' || !$self->{is_wd3};
+        if $self->browser_name ne 'firefox' || !$FORCE_WD3;
     $args->{'extra_capabilities'} = \%$extra_capabilities unless $FORCE_WD2;
 
 

--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -881,7 +881,7 @@ sub new_session {
             %$extra_capabilities,
         },
     };
-    $args->{'extra_capabilities'}{'platform'} = $self->platform
+    $args->{'desiredCapabilities'}{'platform'} = $self->platform
         if $self->browser_name ne 'firefox' || !$self->{is_wd3};
     $args->{'extra_capabilities'} = \%$extra_capabilities unless $FORCE_WD2;
 

--- a/lib/Selenium/Remote/WebElement.pm
+++ b/lib/Selenium/Remote/WebElement.pm
@@ -476,9 +476,9 @@ sub get_attribute {
     #Handle global JSONWire emulation flag
     $no_i_really_mean_it = 1 unless $self->{driver}->{emulate_jsonwire};
 
-    return $self->get_property($attr_name) if $self->driver->{is_wd3} && !(grep { $self->driver->browser_name eq $_ } qw{chrome MicrosoftEdge}) && !$no_i_really_mean_it;
-
-    my $res = {
+    my $prop = $self->get_property($attr_name) if $self->driver->{is_wd3} && !(grep { $self->driver->browser_name eq $_ } qw{chrome MicrosoftEdge}) && !$no_i_really_mean_it;
+    return $prop
+        if $prop;
         'command' => 'getElementAttribute',
         'id'      => $self->id,
         'name'    => $attr_name,
@@ -499,7 +499,11 @@ Only available on WebDriver 3 enabled servers.
 sub get_property {
     my ($self,$prop) = @_;
     return $self->get_attribute($prop) if $self->driver->{is_wd3} && (grep { $self->driver->browser_name eq $_ } qw{chrome MicrosoftEdge});
-    my $res = { 'command' => 'getElementProperty', id => $self->id, name => $prop };
+    my $res = {
+        'command' => 'getElementProperty',
+        'id'      => $self->id,
+        'name'    => $prop,
+    };
     return $self->_execute_command($res);
 }
 

--- a/lib/Selenium/Remote/WebElement.pm
+++ b/lib/Selenium/Remote/WebElement.pm
@@ -476,9 +476,11 @@ sub get_attribute {
     #Handle global JSONWire emulation flag
     $no_i_really_mean_it = 1 unless $self->{driver}->{emulate_jsonwire};
 
-    my $prop = $self->get_property($attr_name) if $self->driver->{is_wd3} && !(grep { $self->driver->browser_name eq $_ } qw{chrome MicrosoftEdge}) && !$no_i_really_mean_it;
+    my $prop;
+    $prop = $self->get_property($attr_name) if $self->driver->{is_wd3} && !(grep { $self->driver->browser_name eq $_ } qw{chrome MicrosoftEdge}) && !$no_i_really_mean_it;
     return $prop
         if $prop;
+    my $res = {
         'command' => 'getElementAttribute',
         'id'      => $self->id,
         'name'    => $attr_name,


### PR DESCRIPTION
Don't return after getting the properties if none was found.