### PR TITLE
Remove get /status restriction on firefox/geckodriver

### DIFF
--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -959,11 +959,8 @@ sub _request_new_session {
         delete $args->{extra_capabilities};
     }
 
-    # geckodriver has not yet implemented the GET /status endpoint
-    # https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/WebDriver/status
-    if (! $self->isa('Selenium::Firefox')) {
-        $self->remote_conn->check_status();
-    }
+    $self->remote_conn->check_status();
+
     # command => 'newSession' to fool the tests of commands implemented
     # TODO: rewrite the testing better, this is so fragile.
     my $resource_new_session = {

--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -959,6 +959,7 @@ sub _request_new_session {
         delete $args->{extra_capabilities};
     }
 
+    # Get actual status
     $self->remote_conn->check_status();
 
     # command => 'newSession' to fool the tests of commands implemented


### PR DESCRIPTION
Remove the geckodriver restriction for the GET /status endpoint.
Version 0.12.0 added status on 2017-01-03
See: https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/WebDriver/status