### PR TITLE
Add context to error handler. Fixes #378

### DIFF
--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -795,7 +795,7 @@ around '_execute_command' => sub {
     }
     catch {
         if ($self->has_error_handler) {
-            return $self->error_handler->($self,$_,@args);
+            $return_value = $self->error_handler->($self,$_,@args);
         }
         else {
             croak $_;

--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -780,6 +780,9 @@ sub DEMOLISH {
 
 # We install an 'around' because we can catch more exceptions this way
 # than simply wrapping the explicit croaks in _execute_command.
+# @args should be fed to the handler to provide context
+# return_value could be assigned from the handler if we want to allow the
+# error_handler to handle the errors
 
 around '_execute_command' => sub {
     my $orig = shift;
@@ -792,7 +795,7 @@ around '_execute_command' => sub {
     }
     catch {
         if ($self->has_error_handler) {
-            $self->error_handler->($self,$_);
+            return $self->error_handler->($self,$_,@args);
         }
         else {
             croak $_;


### PR DESCRIPTION
Pass the arguments used to the user provided error handler, and returns its answer to allow it to fix the error if possible