### PR TITLE
fix search for unix binary on MacOS

### DIFF
--- a/lib/Selenium/CanStartBinary.pm
+++ b/lib/Selenium/CanStartBinary.pm
@@ -423,8 +423,7 @@ sub shutdown_unix_binary {
     my ($self) = @_;
     if (!IS_WIN) {
         my $cmd = "lsof -t -i :".$self->port();
-        my $pid = `$cmd`;
-        chomp $pid;
+        my ( $pid ) = grep { $_ && $_ ne $$ } split /\s+/, scalar `$cmd`;
         if ($pid) {
             print "Killing Driver PID $pid listening on port ".$self->port."...\n";
             eval { kill 'KILL', $pid };


### PR DESCRIPTION
On MacOS, the `lsof -i :<port>` command seems to show multiple processes
have the port open, one of which is the current Perl program. Since this
one mostly comes first in the output, `shutdown_unix_binary` tries to
kill the `perl` process, not the browser process. Filtering out the
current `perl` process from the process we're trying to kill fixes this
issue.

Before this change, the `t/CanStartBinary.t` test exited with signal 9 and the following output:

```
$ RELEASE_TESTING=1 prove t/CanStartBinary.t
t/CanStartBinary.t .. 1/? Could not kill driver process! you may have to clean up manually. at /Users/doug/perl/Selenium-Remote-Driver/lib/Selenium/CanStartBinary.pm line 431.
t/CanStartBinary.t .. 5/? Could not kill driver process! you may have to clean up manually. at /Users/doug/perl/Selenium-Remote-Driver/lib/Selenium/CanStartBinary.pm line 431.
t/CanStartBinary.t .. All 11 subtests passed

Test Summary Report
-------------------
t/CanStartBinary.t (Wstat: 9 Tests: 11 Failed: 0)
  Non-zero wait status: 9
  Parse errors: No plan found in TAP output
Files=1, Tests=11, 14 wallclock secs ( 0.04 usr  0.01 sys +  0.56 cusr  0.33 csys =  0.94 CPU)
Result: FAIL
```

After this patch, everything passes successfully:

```
$ RELEASE_TESTING=1 prove t/CanStartBinary.t
t/CanStartBinary.t .. ok
All tests successful.
Files=1, Tests=20, 22 wallclock secs ( 0.03 usr  0.01 sys +  0.58 cusr  0.46 csys =  1.08 CPU)
Result: PASS
```