### PR TITLE
Driver.pm screenshot method referenced incorrect

### DIFF
--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -2181,7 +2181,7 @@ sub screenshot {
     my ($self, $params) = @_;
     $params //= { full => 0 };
 
-    croak "Full page screenshot only supported on geckodriver" if $params->{full} && ( $self->{browser} ne 'firefox' );
+    croak "Full page screenshot only supported on geckodriver" if $params->{full} && ( $self->{browser_name} ne 'firefox' );
 
     my $res = { 'command' => $params->{'full'} == 1 ? 'mozScreenshotFull' : 'screenshot' };
     return $self->_execute_command($res);


### PR DESCRIPTION
Variable name $self->{browser} doesn't exist. Needed to be:
$self->{browser_name} for the croak