### PR TITLE
Added W3C WebDriver support when using Chrome

### DIFF
--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -1223,8 +1223,6 @@ sub get_alert_text {
 
     # include the WDKeys module
     use Selenium::Remote::WDKeys;
-    .
-    .
     $driver->send_keys_to_active_element(KEYS->{'space'}, KEYS->{'enter'});
 
 =cut

--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -2443,7 +2443,7 @@ sub set_window_size {
 
 sub maximize_window {
     my ( $self, $window ) = @_;
- 
+
     $window = ( defined $window ) ? $window : 'current';
     my $res = { 'command' => 'maximizeWindow', 'window_handle' => $window };
     my $ret = $self->_execute_command($res);

--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -243,15 +243,11 @@ This is because the gecko driver prefers legacy capabilities, both of which are 
 
 =head2 Chrome Notes
 
-extra_capabilities may? not work, because chromedriver considers the chromeOptions parameter to be invalid, despite it's documentation here:
+Use the option goog:chromeOptions instead of chromeOptions, if you are intending to pass extra_capabilities on a
+WD3 enabled server with chromedriver enabled.
 
     https://sites.google.com/a/chromium.org/chromedriver/capabilities
 
-Other bindings get around this by just using the 'old' way of passing desired capabilities.  You can do this too like so:
-
-    $Selenium::Remote::Driver::FORCE_WD2=1;
-
-This is now forced on during construction for chrome.
 
 =head1 CONSTRUCTOR
 
@@ -374,7 +370,7 @@ Usage:
     #or
     my $driver = Selenium::Remote::Driver->new('browser_name' =>'chrome',
                                                'extra_capabilities' => {
-                                                   'chromeOptions' => {
+                                                   'goog:chromeOptions' => {
                                                        'args'  => [
                                                            'window-size=1260,960',
                                                            'incognito'
@@ -896,9 +892,6 @@ sub new_session {
     my ( $self, $extra_capabilities ) = @_;
     $extra_capabilities ||= {};
 
-    #XXX chromedriver is broken
-    $FORCE_WD2 = 1 if $self->browser_name eq 'chrome';
-
     my $args = {
         'desiredCapabilities' => {
             'browserName'       => $self->browser_name,
@@ -970,7 +963,7 @@ sub _request_new_session {
               if $args->{desiredCapabilities}->{browserName} eq 'firefox';
 
 #XXX the chrome documentation is lies, you can't do this yet
-#$args->{capabilities}->{alwaysMatch}->{'chromeOptions'}      = $args->{capabilities}->{alwaysMatch}->{$cap} if $args->{desiredCapabilities}->{browserName} eq 'chrome';
+#$args->{capabilities}->{alwaysMatch}->{'goog:chromeOptions'}      = $args->{capabilities}->{alwaysMatch}->{$cap} if $args->{desiredCapabilities}->{browserName} eq 'chrome';
 #Does not appear there are any MSIE based options, so let's just let that be
         }
         if (   exists( $args->{desiredCapabilities}->{browserName} )
@@ -1026,8 +1019,8 @@ sub _request_new_session {
     #Fix broken out of the box chrome because they hate the maintainers of their interfaces
     if ( $self->isa('Selenium::Chrome') ) {
         if ( exists $args->{desiredCapabilities} ) {
-            $args->{desiredCapabilities}{chromeOptions}{args} //= [];
-            push(@{$args->{desiredCapabilities}{chromeOptions}{args}}, qw{no-sandbox disable-dev-shm-usage});
+            $args->{desiredCapabilities}{'goog:chromeOptions'}{args} //= [];
+            push(@{$args->{desiredCapabilities}{'goog:chromeOptions'}{args}}, qw{no-sandbox disable-dev-shm-usage});
         }
     }
 
@@ -1240,7 +1233,7 @@ sub send_keys_to_active_element {
     my ( $self, @strings ) = @_;
 
     if ( $self->{is_wd3}
-        && !( grep { $self->browser_name eq $_ } qw{chrome MicrosoftEdge} ) )
+        && !( grep { $self->browser_name eq $_ } qw{MicrosoftEdge} ) )
     {
         @strings = map { split( '', $_ ) } @strings;
         my @acts = map {
@@ -1469,7 +1462,7 @@ sub mouse_move_to_location {
     $params{element} = $params{element}{id} if exists $params{element};
 
     if ( $self->{is_wd3}
-        && !( grep { $self->browser_name eq $_ } qw{chrome MicrosoftEdge} ) )
+        && !( grep { $self->browser_name eq $_ } qw{MicrosoftEdge} ) )
     {
         my $origin      = $params{element};
         my $move_action = {
@@ -1789,7 +1782,7 @@ sub get_window_size {
     $window = ( defined $window ) ? $window : 'current';
     my $res = { 'command' => 'getWindowSize', 'window_handle' => $window };
     $res = { 'command' => 'getWindowRect', handle => $window }
-      if $self->{is_wd3} && $self->browser_name ne 'chrome';
+      if $self->{is_wd3};
     return $self->_execute_command($res);
 }
 
@@ -1819,7 +1812,7 @@ sub get_window_position {
     $window = ( defined $window ) ? $window : 'current';
     my $res = { 'command' => 'getWindowPosition', 'window_handle' => $window };
     $res = { 'command' => 'getWindowRect', handle => $window }
-      if $self->{is_wd3} && $self->browser_name ne 'chrome';
+      if $self->{is_wd3};
     return $self->_execute_command($res);
 }
 
@@ -2020,7 +2013,7 @@ sub execute_async_script {
             if ( Scalar::Util::blessed( $args[$i] )
                 and $args[$i]->isa('Selenium::Remote::WebElement') )
             {
-                if ( $self->{is_wd3} && $self->browser_name ne 'chrome' ) {
+                if ( $self->{is_wd3} ) {
                     $args[$i] =
                       { 'element-6066-11e4-a52e-4f735466cecf' =>
                           ( $args[$i] )->{id} };
@@ -2094,7 +2087,7 @@ sub execute_script {
             if ( Scalar::Util::blessed( $args[$i] )
                 and $args[$i]->isa('Selenium::Remote::WebElement') )
             {
-                if ( $self->{is_wd3} && $self->browser_name ne 'chrome' ) {
+                if ( $self->{is_wd3} ) {
                     $args[$i] =
                       { 'element-6066-11e4-a52e-4f735466cecf' =>
                           ( $args[$i] )->{id} };
@@ -2269,7 +2262,7 @@ sub switch_to_frame {
 
     my $res = { 'command' => 'switchToFrame' };
     if ( ref $id eq $self->webelement_class ) {
-        if ( $self->{is_wd3} && $self->browser_name ne 'chrome' ) {
+        if ( $self->{is_wd3} ) {
             $params =
               { 'id' =>
                   { 'element-6066-11e4-a52e-4f735466cecf' => $id->{'id'} } };
@@ -2376,7 +2369,7 @@ sub set_window_position {
     $y += 0;
     my $res = { 'command' => 'setWindowPosition', 'window_handle' => $window };
     my $params = { 'x' => $x, 'y' => $y };
-    if ( $self->{is_wd3} && $self->browser_name ne 'chrome' ) {
+    if ( $self->{is_wd3} ) {
         $res = { 'command' => 'setWindowRect', handle => $window };
     }
     my $ret = $self->_execute_command( $res, $params );
@@ -2420,7 +2413,7 @@ sub set_window_size {
     $width += 0;
     my $res = { 'command' => 'setWindowSize', 'window_handle' => $window };
     my $params = { 'height' => $height, 'width' => $width };
-    if ( $self->{is_wd3} && $self->browser_name ne 'chrome' ) {
+    if ( $self->{is_wd3} ) {
         $res = { 'command' => 'setWindowRect', handle => $window };
     }
     my $ret = $self->_execute_command( $res, $params );
@@ -2452,12 +2445,7 @@ sub set_window_size {
 
 sub maximize_window {
     my ( $self, $window ) = @_;
-    if ( $self->{is_wd3} && $self->browser_name eq 'chrome' ) {
-        my $h = $self->execute_script(q{return screen.availHeight});
-        my $w = $self->execute_script(q{return screen.availWidth});
-
-        return $self->set_window_size( $h, $w );
-    }
+ 
     $window = ( defined $window ) ? $window : 'current';
     my $res = { 'command' => 'maximizeWindow', 'window_handle' => $window };
     my $ret = $self->_execute_command($res);
@@ -3218,7 +3206,7 @@ sub send_modifier {
     }
 
     if ( $self->{is_wd3}
-        && !( grep { $self->browser_name eq $_ } qw{chrome MicrosoftEdge} ) )
+        && !( grep { $self->browser_name eq $_ } qw{MicrosoftEdge} ) )
     {
         my $acts = [
             {
@@ -3302,7 +3290,7 @@ sub click {
     my $params = { 'button'  => $button };
 
     if ( $self->{is_wd3}
-        && !( grep { $self->browser_name eq $_ } qw{chrome MicrosoftEdge} ) )
+        && !( grep { $self->browser_name eq $_ } qw{MicrosoftEdge} ) )
     {
         $params = {
             actions => [
@@ -3366,7 +3354,7 @@ sub double_click {
     $button = _get_button($button);
 
     if ( $self->{is_wd3}
-        && !( grep { $self->browser_name eq $_ } qw{chrome MicrosoftEdge} ) )
+        && !( grep { $self->browser_name eq $_ } qw{MicrosoftEdge} ) )
     {
         $self->click( $button, 1 );
         $self->click( $button, 1 );
@@ -3398,7 +3386,7 @@ sub button_down {
     my ($self) = @_;
 
     if ( $self->{is_wd3}
-        && !( grep { $self->browser_name eq $_ } qw{chrome MicrosoftEdge} ) )
+        && !( grep { $self->browser_name eq $_ } qw{MicrosoftEdge} ) )
     {
         my $params = {
             actions => [
@@ -3445,7 +3433,7 @@ sub button_up {
     my ($self) = @_;
 
     if ( $self->{is_wd3}
-        && !( grep { $self->browser_name eq $_ } qw{chrome MicrosoftEdge} ) )
+        && !( grep { $self->browser_name eq $_ } qw{MicrosoftEdge} ) )
     {
         my $params = {
             actions => [

--- a/lib/Selenium/Remote/Spec.pm
+++ b/lib/Selenium/Remote/Spec.pm
@@ -142,7 +142,7 @@ has '_caps' => (
             'proxy',                   'pageLoadStrategy',
             'setWindowRect',           'timeouts',
             'unhandledPromptBehavior', 'moz:firefoxOptions',
-            'chromeOptions',
+            'goog:chromeOptions',
         ];
     }
 );

--- a/lib/Selenium/Remote/WebElement.pm
+++ b/lib/Selenium/Remote/WebElement.pm
@@ -166,7 +166,7 @@ sub submit {
     if (
         $self->driver->{is_wd3}
         && !(
-            grep { $self->driver->browser_name eq $_ } qw{chrome MicrosoftEdge}
+            grep { $self->driver->browser_name eq $_ } qw{MicrosoftEdge}
         )
       )
     {
@@ -457,7 +457,7 @@ sub get_element_location_in_view {
     }, { 'element-6066-11e4-a52e-4f735466cecf' => $self->{id} }
       )
       if $self->driver->{is_wd3} && grep { $self->driver->browser_name eq $_ }
-      ( 'firefox', 'internet explorer' );
+      ( 'firefox', 'internet explorer', 'chrome' );
     my $res = { 'command' => 'getElementLocationInView', 'id' => $self->id };
     return $self->_execute_command($res);
 }

--- a/t/01-webdriver3.t
+++ b/t/01-webdriver3.t
@@ -93,9 +93,9 @@ NEWSESS: {
     is($self->{capabilities},'eee',"Caps set correctly in wd3 mode");
     is_deeply($args_modified->{capabilities},$expected,"Desired capabilities correctly translated to Firefox (WD3)");
 
-    #$expected->{alwaysMatch}->{'chromeOptions'} = $expected->{alwaysMatch}->{'moz:firefoxOptions'};
+    #$expected->{alwaysMatch}->{'goog:chromeOptions'} = $expected->{alwaysMatch}->{'moz:firefoxOptions'};
     $expected->{alwaysMatch}->{'moz:firefoxOptions'} = {};
-    #$expected->{alwaysMatch}->{chromeOptions}->{args} = ['-profile', '~/.mozilla/firefox/vbdgri9o.default'];
+    #$expected->{alwaysMatch}->{'goog:chromeOptions'}->{args} = ['-profile', '~/.mozilla/firefox/vbdgri9o.default'];
     $expected->{alwaysMatch}->{browserName} = 'chrome';
 
     $args->{desiredCapabilities}->{browserName} = 'chrome';


### PR DESCRIPTION
Added W3C WebDriver support for Chrome which provides the ability to use Chrome and chromedriver v75+ in default w3c mode.

https://chromium.googlesource.com/chromium/src/+/master/docs/chromedriver_status.md
https://chromedriver.storage.googleapis.com/75.0.3770.8/notes.txt