### PR TITLE
#449: fix chromedriver performance logging

### DIFF
--- a/lib/Selenium/Remote/Spec.pm
+++ b/lib/Selenium/Remote/Spec.pm
@@ -142,7 +142,7 @@ has '_caps' => (
             'proxy',                   'pageLoadStrategy',
             'setWindowRect',           'timeouts',
             'unhandledPromptBehavior', 'moz:firefoxOptions',
-            'goog:chromeOptions',
+            'goog:chromeOptions',      'goog:loggingPrefs',
         ];
     }
 );


### PR DESCRIPTION
Added 'goog:loggingPrefs', to _caps array.