### PR TITLE
make waiter timeout recognizable

### DIFF
--- a/lib/Selenium/Waiter.pm
+++ b/lib/Selenium/Waiter.pm
@@ -93,7 +93,9 @@ sub wait_until (&%) {
     my $start               = time;
     my $timeout_not_elapsed = sub {
         my $elapsed = time - $start;
-        return $elapsed < $args->{timeout};
+        my $ret = $elapsed < $args->{timeout};
+        warn 'timeout' if ( !$ret && $args->{debug} );
+        return $ret;
     };
 
     my $exception = '';

--- a/lib/Selenium/Waiter.pm
+++ b/lib/Selenium/Waiter.pm
@@ -93,9 +93,7 @@ sub wait_until (&%) {
     my $start               = time;
     my $timeout_not_elapsed = sub {
         my $elapsed = time - $start;
-        my $ret = $elapsed < $args->{timeout};
-        warn 'timeout' if ( !$ret && $args->{debug} );
-        return $ret;
+        return $elapsed < $args->{timeout};
     };
 
     my $exception = '';
@@ -120,6 +118,8 @@ sub wait_until (&%) {
         return $try_ret if $try_ret;
     }
 
+    warn 'timeout' if $args->{debug};
+    
     # No need to repeat ourselves if we're already debugging.
     warn $exception if $exception && !$args->{debug};
     return '';

--- a/t/13-waiter.t
+++ b/t/13-waiter.t
@@ -1,0 +1,44 @@
+use strict;
+use warnings;
+
+use Selenium::Waiter;
+
+use FindBin;
+use lib $FindBin::Bin . '/lib';
+use Test::More;
+
+my $res;
+
+subtest 'basic' => sub {
+    $res = wait_until { 1 };
+    is $res, 1, 'right return value';
+
+    $res = wait_until { 0 } timeout => 1;
+    is $res, '', 'right return value';
+};
+
+subtest 'exception' => sub {
+    my @warning;
+    local $SIG{__WARN__} = sub { push( @warning, $_[0] ) };
+
+    $res = wait_until { die 'case1' } debug => 0, timeout => 1;
+    is $res, '', 'right return value';
+    is( scalar @warning, 1, 'right number of warnings' );
+    like( $warning[0], qr{^case1}, 'right warning' );
+
+    @warning = ();
+    eval {
+        $res = wait_until { die 'case2' } die => 1, timeout => 1;
+    };
+    like $@, qr{case2}, 'right error';
+    is $res, '',        'right return value';
+    is( scalar @warning, 0, 'right number of warnings' );
+
+    @warning = ();
+    $res     = wait_until { 0 } debug => 1, timeout => 1;
+    is $res, '', 'right return value';
+    is( scalar @warning, 1, 'right number of warnings' );
+    like( $warning[0], qr{timeout}i, 'timeout is reported' );
+};
+
+done_testing;

--- a/t/13-waiter.t
+++ b/t/13-waiter.t
@@ -10,11 +10,16 @@ use Test::More;
 my $res;
 
 subtest 'basic' => sub {
+    my @warning;
+    local $SIG{__WARN__} = sub { push( @warning, $_[0] ) };
+
     $res = wait_until { 1 };
     is $res, 1, 'right return value';
 
     $res = wait_until { 0 } timeout => 1;
     is $res, '', 'right return value';
+
+    is( scalar @warning, 0, 'no warnings' );
 };
 
 subtest 'exception' => sub {


### PR DESCRIPTION
When wait_until elapsed timeout, it's hard to distinguish it from assertion success.
The PR makes debug mode to warn 'timeout' when it is.
